### PR TITLE
Bump new version: v2.6

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,7 +2,7 @@
     "description": "<p>The pipeline</p>\n\n<p>ngs-preprocess is built using Nextflow, a workflow tool to run tasks across multiple compute infrastructures in a very portable manner. It uses Docker/Singularity containers making installation trivial and results highly reproducible. It is an easy to use pipeline that uses state-of-the-art software for quality check and pre-processing ngs reads of Illumina, Pacbio and Oxford Nanopore Technologies.</p>", 
     "license": "other-open", 
     "title": "fmalmeida/ngs-preprocess: A pipeline for preprocessing short and long sequencing reads", 
-    "version": "v2.5", 
+    "version": "v2.6", 
     "upload_type": "software",
     "creators": [
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The tracking for changes started in v2.2
 
+## v2.6 -- [2023-Apr-16]
+
+Small bug fixes on SRA_FETCH download modules. Updated pipeline to understand Illumina / BGIseq sequences for short reads. Updated Docker image with named versions of tools whenever possible.
+
+> More tools have been added so the versioning and docker image have now changed to v2.6.
+
 ## v2.5 -- [2022-Oct-30]
 
 Add possibility for users to automatically fetch fastq files from SRA NCBI database. For that, users just need to use the `--sra_ids` parameter, passing a file with a list of SRA RunIDs, one per line.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ COPY environment.yml /
 RUN mamba env create --quiet -f /environment.yml && mamba clean -a
 
 # Add conda installation dir to PATH (instead of doing 'conda activate')
-ENV PATH /opt/conda/envs/ngs-preprocess-2.5/bin:$PATH
+ENV PATH /opt/conda/envs/ngs-preprocess-2.6/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
-RUN conda env export --name ngs-preprocess-2.5 > ngs-preprocess-2.5.yml
+RUN conda env export --name ngs-preprocess-2.6 > ngs-preprocess-2.6.yml
 
 # cp config
 RUN cp -R /root/.ncbi / && chmod -R 777 /root/.ncbi /.ncbi

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ It wraps up the following software:
 | SRA NBCI fetch | [Entrez-direct](https://anaconda.org/bioconda/entrez-direct) & [sra-tools](https://github.com/ncbi/sra-tools) |
 | Illumina pre-processing | [Fastp](https://github.com/OpenGene/fastp) |
 | Nanopore pre-processing | [Porechop](https://github.com/rrwick/Porechop), [pycoQC](https://github.com/tleonardi/pycoQC), [NanoPack](https://github.com/wdecoster/nanopack) |
-| Pacbio pre-processing | [bam2fastx](https://github.com/PacificBiosciences/bam2fastx), [bax2bam](https://github.com/PacificBiosciences/bax2bam), [lima](https://github.com/PacificBiosciences/barcoding), [pacbio ccs](https://ccs.how/) |
+| Pacbio pre-processing | [bam2fastx](https://github.com/PacificBiosciences/pbtk#bam2fastx), [bax2bam](https://anaconda.org/bioconda/bax2bam), [lima](https://github.com/PacificBiosciences/barcoding), [pacbio ccs](https://ccs.how/) |
 
 ## Further reading
 
@@ -67,7 +67,7 @@ This pipeline has two complementary pipelines (also written in nextflow) for [ge
 
         ```bash
         # for docker
-        docker pull fmalmeida/ngs-preprocess:v2.5
+        docker pull fmalmeida/ngs-preprocess:v2.6
 
         # run
         nextflow run fmalmeida/ngs-preprocess -profile docker [options]
@@ -83,7 +83,7 @@ This pipeline has two complementary pipelines (also written in nextflow) for [ge
         export NXF_SINGULARITY_CACHEDIR=MY_SINGULARITY_CACHE       # your singularity cache dir
         singularity pull \
             --dir $NXF_SINGULARITY_LIBRARYDIR \
-            fmalmeida-ngs-preprocess-v2.5.img docker://fmalmeida/ngs-preprocess:v2.5
+            fmalmeida-ngs-preprocess-v2.6.img docker://fmalmeida/ngs-preprocess:v2.6
         
         # run
         nextflow run fmalmeida/ngs-preprocess -profile singularity [options]
@@ -218,8 +218,8 @@ In addition, users are encouraged to cite the programs used in this pipeline whe
 * [Fastp](https://github.com/OpenGene/fastp)
 * [Porechop](https://github.com/rrwick/Porechop)
 * [pycoQC](https://github.com/a-slide/pycoQC)
-* [bax2bam](https://github.com/PacificBiosciences/bax2bam)
-* [bam2fastq](https://github.com/PacificBiosciences/bam2fastx)
+* [bax2bam](https://anaconda.org/bioconda/bax2bam)
+* [bam2fastq](https://github.com/PacificBiosciences/pbtk#bam2fastx)
 * [lima](https://github.com/PacificBiosciences/barcoding)
 * [pacbio ccs](https://ccs.how/)
 * [NanoPack](https://github.com/wdecoster/nanopack).

--- a/conf/conda.config
+++ b/conf/conda.config
@@ -2,5 +2,5 @@
 singularity.enabled = false
 docker.enabled      = false
 process {
-    conda = "$CONDA_PREFIX/envs/ngs-preprocess-2.5"
+    conda = "$CONDA_PREFIX/envs/ngs-preprocess-2.6"
 }

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -2,4 +2,4 @@
 singularity.enabled = false
 docker.enabled      = true
 docker.runOptions   = '-u \$(id -u):\$(id -g)'
-process.container   = "fmalmeida/ngs-preprocess:v2.5"
+process.container   = "fmalmeida/ngs-preprocess:v2.6"

--- a/conf/singularity.config
+++ b/conf/singularity.config
@@ -2,5 +2,5 @@
 docker.enabled         = false
 singularity.enabled    = true
 singularity.autoMounts = true
-process.container      = "docker://fmalmeida/ngs-preprocess:v2.5"
+process.container      = "docker://fmalmeida/ngs-preprocess:v2.6"
 singularity.autoMounts = true

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,11 +45,11 @@ It wraps up the following tools:
 
   * - bax2bam
     - Convert PacBio bax files to bam
-    - https://github.com/PacificBiosciences/bax2bam
+    - https://anaconda.org/bioconda/bax2bam
 
   * - bam2fastx
     - Extract reads from PacBio bam files
-    - https://github.com/PacificBiosciences/bam2fastx
+    - https://github.com/PacificBiosciences/pbtk#bam2fastx
 
   * - lima
     - PacBio reads demultiplexing

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -31,7 +31,7 @@ This pipeline `Nextflow <https://www.nextflow.io/docs/latest/index.html>`_ requi
    .. code-block:: bash
       
       # for docker
-      docker pull fmalmeida/ngs-preprocess:v2.5
+      docker pull fmalmeida/ngs-preprocess:v2.6
       nextflow run fmalmeida/ngs-preprocess -profile docker [options]
 
       # for singularity
@@ -41,7 +41,7 @@ This pipeline `Nextflow <https://www.nextflow.io/docs/latest/index.html>`_ requi
       export NXF_SINGULARITY_CACHEDIR=MY_SINGULARITY_CACHE       # your singularity cache dir
       singularity pull \
             --dir $NXF_SINGULARITY_LIBRARYDIR \
-            fmalmeida-ngs-preprocess-v2.5.img docker://fmalmeida/ngs-preprocess:v2.5
+            fmalmeida-ngs-preprocess-v2.6.img docker://fmalmeida/ngs-preprocess:v2.6
       nextflow run fmalmeida/ngs-preprocess -profile singularity [options]
 
       # for conda

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 # You can use this file to create a conda environment for this pipeline:
 #   conda env create -f environment.yml
-name: ngs-preprocess-2.5
+name: ngs-preprocess-2.6
 channels:
   - conda-forge
   - bioconda
@@ -22,20 +22,23 @@ dependencies:
   - conda-forge::gcc
 
   ## bioconda packages
-  - bioconda::porechop
-  - bioconda::fastp
+  - bioconda::porechop=0.2.4
+  - bioconda::fastp=0.23.2
   - bioconda::samtools
   - bioconda::bax2bam=0.0.9
-  - bioconda::bam2fastx
-  - bioconda::pbccs
-  - bioconda::lima
+  - bioconda::pbtk=3.1.0
+  - bioconda::pbccs=6.4.0
+  - bioconda::lima=2.7.1
   - bioconda::pbbam>=0.23.0
-  - bioconda::pycoqc
+  - bioconda::pycoqc=2.5.0.3
   - bioconda::pysam
-  - bioconda::nanoqc
+  - bioconda::nanoqc=0.9.4
   - bioconda::nanostat
-  - bioconda::nanoplot>=1.38.1
-  - bioconda::nanofilt
-  - bioconda::sra-tools
-  - bioconda::entrez-direct
+  - bioconda::nanoplot=1.41.0
+  - bioconda::nanofilt=2.8.0
+  - bioconda::sra-tools=3.0.3
+  - bioconda::entrez-direct=16.2
   - bioconda::csvtk
+
+  ## other
+  - plotly::plotly

--- a/main.nf
+++ b/main.nf
@@ -156,7 +156,7 @@ workflow {
   .filter{ it != '' }
   .mix( 
     SRA_FETCH.out.fastqs
-    .filter{ it[1] =~ /illumina/ }
+    .filter{ it[1] =~ /illumina|bgiseq/ }
     .map{ 
       def meta             = [:]
       meta.id              = it[0]

--- a/modules/get_fastq.nf
+++ b/modules/get_fastq.nf
@@ -9,6 +9,8 @@ process GET_FASTQ {
   output:
   path "*_data", emit: sra_fastq
 
+  when: sra_ids
+
   script:
   def sra_ids = "${sra_ids.replaceAll(~/\s/,'')}"
   """

--- a/modules/get_fastq.nf
+++ b/modules/get_fastq.nf
@@ -14,6 +14,12 @@ process GET_FASTQ {
   script:
   def sra_ids = "${sra_ids.replaceAll(~/\s/,'')}"
   """
-  fastq-dump --gzip --split-3 --outdir ./${sra_ids}_data $sra_ids
+  fasterq-dump \\
+    --include-technical \\
+    --split-files \\
+    --threads $task.cpus \\
+    --outdir ./${sra_ids}_data \\
+    --progress \\
+    $sra_ids
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -93,5 +93,5 @@ manifest {
   homePage        = "https://github.com/fmalmeida/ngs-preprocess"
   mainScript      = "main.nf"
   nextflowVersion = ">=21.10.0"
-  version         = "2.5"
+  version         = "2.6"
 }

--- a/workflows/pacbio.nf
+++ b/workflows/pacbio.nf
@@ -33,6 +33,7 @@ workflow PACBIO {
       def meta    = [:]
       meta.id     = it.getBaseName() - ".bam" - ".subreads"
       meta.design = (params.pacbio_barcode_design.toLowerCase() != 'same' && params.pacbio_barcode_design.toLowerCase() != 'different') ? '' : '--' + params.pacbio_barcode_design.toLowerCase()
+      meta.longreads_type = 'pacbio'
 
       [ meta, it ]
     }


### PR DESCRIPTION
Small bugfixes. Updated Docker image with named versions and accepts Illumina / BGIseq as short reads.